### PR TITLE
Downgrade doxygen

### DIFF
--- a/src/wurfapi/doxygen_downloader.py
+++ b/src/wurfapi/doxygen_downloader.py
@@ -28,6 +28,12 @@ else:
 
 BASE_URL = "http://ftp.stack.nl/pub/users/dimitri/"
 
+# Version 1.8.13 segfaults if the C++ code has any friend declarations
+# as described here:
+# https://bugzilla.gnome.org/show_bug.cgi?id=777941
+# This regression was fixed here:
+# https://bugzilla.gnome.org/show_bug.cgi?id=776791
+
 # Version 1.8.14 has a broken Linux binary:
 # https://bugzilla.gnome.org/show_bug.cgi?id=792761
 # it is linked with libclang but does not ship with it, so you get the following
@@ -38,7 +44,7 @@ BASE_URL = "http://ftp.stack.nl/pub/users/dimitri/"
 #
 # Running ldd gives:
 #
-# 	linux-vdso.so.1 =>  (0x00007ffc883a8000)
+#   linux-vdso.so.1 =>  (0x00007ffc883a8000)
 #   libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f39d96e3000)
 #   libclang.so.6 => not found
 #   libtinfo.so.5 => /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007f39d94ba000)

--- a/src/wurfapi/doxygen_downloader.py
+++ b/src/wurfapi/doxygen_downloader.py
@@ -49,7 +49,7 @@ BASE_URL = "http://ftp.stack.nl/pub/users/dimitri/"
 #   libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f39d85ca000)
 #   /lib64/ld-linux-x86-64.so.2 (0x00007f39d9902000)
 
-VERSION = "1.8.13"
+VERSION = "1.8.12"
 
 
 class DoxygenUnsupportedError(WurfapiError):


### PR DESCRIPTION
@mortenvp Do you have any objections against downgrading to Doxygen 1.8.12?

I noticed that 1.8.13 always segfaults when the C++ code has a friend declaration.
This is quite problematic in our wrappers, e.g. https://github.com/steinwurf/kodo-rlnc/blob/master/src/kodo_rlnc/encoder.hpp#L202
If we use Doxygen 1.8.12, then everything looks good and I could generate this:
http://docs.steinwurf.com/kodo-rlnc/master/api/encoder.html

Normally we would go forward, but you noted that 1.8.14 is also broken, so downgrading seems to be the only option here :(